### PR TITLE
Fix text/background coloring of ads and result info

### DIFF
--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12e
+     * Version: v3.1.12f
      */
 
      /* Main Background Color*/
@@ -695,7 +695,7 @@
     .dw-sb-cont .dw-sb-btn {
         background: var(--container-bg-color) !important;
     }
-    ._wtf {
+    ._wtf._Qtf:not(.sbico) {
         filter: invert(1) !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  Nass O & hyperfekt
-     * Version: v3
+     * Version: v3.1
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.4a
+     * Version: v3.1.5
      */
 
      /* Main Background Color*/
@@ -128,7 +128,7 @@
     }
 
     /* TextD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -620,6 +620,15 @@
         fill: #161616 !important;
     }
 
+    /* 'things to do' compass */
+    ._x7n._v4r {
+        filter: brightness(400%) !important;
+    }
+    /* 'things to do' borders */
+    ._G4n td {
+        border-color: #636363;
+    }
+    
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -23,28 +23,18 @@
     }
     /* Inverting colors */
     .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW {
-        -webkit-filter: invert(1) grayscale(1) !important;
-        -moz-filter: invert(1) grayscale(1) !important;
         filter: invert(1) grayscale(1) !important;
     }
     ._Zgf {
-        -webkit-filter: invert(0.6) grayscale(1) !important;
-        -moz-filter: invert(0.6) grayscale(1) !important;
         filter: invert(0.6) grayscale(1) !important;
     }
     .gsri_a, .sbico {
-        -webkit-filter: grayscale(0.6) !important;
-        -moz-filter: grayscale(0.6) !important;
         filter: grayscale(0.6) !important;
     }
     ._n0b, ._MNk._wtf svg {
-        -webkit-filter: invert(0.9) !important;
-        -moz-filter: invert(0.9) !important;
         filter: invert(0.9) !important;
     }
     #qbx {
-        -webkit-filter: invert(0.3) !important;
-        -moz-filter: invert(0.3) !important;
         filter: invert(0.3) !important;
     }
     /* Images opacity */
@@ -87,13 +77,6 @@
         background-color: #222;
     }
 
-    /* Auto completion
-    input#lst-ib.gsfi {
-        background: url(data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D) rgba(34, 34, 34, 0.74)!important;
-
-    }
-    */
-
     /* Header */
     .sfbgg {
         background-color: #151515 !important;
@@ -126,8 +109,7 @@
         border-bottom-color: var(--main-bg-color) !important;
     }
 
-    /* Visited links */
-    /* Titles (blue) #7EB3F3 */
+    /* Titles */
     .rllt__action-button:visited, #gsr .rllt__action-button:active, ._eMi, #sbsb_f, #sbsb_f:hover, a:link, .w, #prs a:visited, #prs a:active, .q:active, .q:visited, .kl:active, .tbotu, a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited {
         color: /*[[LINKCOLOR]]*/;
     }
@@ -135,7 +117,7 @@
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
-    /* Links (blue) #89A2CF*/
+    /* Links */
     a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht {
         color: /*[[LINKCOLOR]]*/ !important;
     }
@@ -150,26 +132,26 @@
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
-    /* Subtext #9f9f9f */
+    /* Subtext */
     .sben_a, ._Lgc .gl, ._Wmc, ._zX, ._gdf, ._RWc, span.f.nsa._uQb, .f a:link, ._uQb, ._bnc, ._Tib, ._Tib a.fl, .f, .f a:link {
         color: #aaa !important;
         font-style: italic !important;
     }
 
-    /* Matching words in search results #D3D3D3*/
+    /* Matching words in search results */
     .ads-creative b, .s .st em, .st.s.std em {
         color: #bdbdbd;
     }
 
-    /* visited links #BD90D7 */
+    /* visited links */
     .mblink:visited, a:visited, .sbpqs_a, a.fl:visited, .st .f .fl:visited {
         color: /*[[VISITEDURLCOLOR]]*/ !important;
     }
-    /* URL color #69AC82 */
+    /* URL color */
     .a, cite, cite a:link, cite a:visited, .cite, .cite:link, #_bGc > i, .bc a:link, ._IId, ._CBw._Clt, ._PHs {
         color: /*[[URLCOLOR]]*/ !important;
     }
-    /* Strong Blue links #54A6F8 */
+    /* Strong Blue links */
     #hdtb-msb .hdtb-mitem.hdtb-msel, #hdtb-msb .hdtb-mitem.hdtb-msel-pre {
         border-bottom: 3px solid #84a6e0 !important;
         color: #84a6e0 !important;
@@ -182,14 +164,14 @@
         color: #eee!important;
     }
 
-    /* Links (white) #c5c5c5 */
+    /* Links (white) */
     .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a {
         color: #a3a3a3 !important;
     }
     .gb_Q span {
         opacity: 1;
     }
-    /* Hover links (white) #E1E1E1 */
+    /* Hover links (white) */
     a._Gs:hover, ._HR a, #swml a:hover, .hdtbItm label:hover, .hdtbItm a:hover, #hdtb-more-mn a:hover, #hdtb .hdtb-mitem a:hover, .hdtb-mn-hd:hover, #hdtb-more:hover, #hdtb-tls:hover {
         color: #e1e1e1 !important;
     }
@@ -201,10 +183,7 @@
 
     /* Button Shadow */
     .jhp input[type='submit'], .sbdd_a input, .gbqfba {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#222), to(#222));
-        background-image: -webkit-linear-gradient(top, #222, #222);
-        background-image: -moz-linear-gradient(center top, #222, #222);
-        background-image: -o-linear-gradient(top, #222, #222);
+        background-image: none;
         background-color: #222;
         border-color: #242424;
         color: #acacac;
@@ -213,9 +192,7 @@
 
     /* Button Shadow Hover */
     .jhp input[type='submit']:hover, .sbdd_a input:hover, .gbqfba:hover {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#2e2e2e), to(#2e2e2e));
-        background-image: -webkit-linear-gradient(top, #2e2e2e, #2e2e2e);
-        background-image: -moz-linear-gradient(center top, #2e2e2e, #2e2e2e);
+        background-image: none;
         background-color: #2e2e2e;
         border-color: #2d2d2d;
         color: #ccc;
@@ -224,17 +201,13 @@
 
     /* Button */
     .ab_button, #hdtb-tls:hover, .ksb {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#222), to(#222));
-        background-image: -webkit-linear-gradient(top, #222, #222);
-        background-image: -moz-linear-gradient(center top, #222, #222);
-        background-image: -o-linear-gradient(top, #222, #222);
+        background-image: none;
         background-color: #222;
         border-color: #262626;
         color: #acacac !important;
     }
     #hdtb-msb .hdtb-tl-sel, #hdtb-msb .hdtb-tl-sel:hover {
-        background: -webkit-linear-gradient(top, #232323, #272727) !important;
-        -webkit-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.1) !important;
+        background: linear-gradient(to bottom, #232323, #272727) !important;
         border: 1px solid #1e1e1e !important;
         box-shadow: inset 0 1px 2px 0 rgba(0,0,0,0.2) !important;
     }
@@ -244,10 +217,7 @@
 
     /* Button Hover */
     .ab_button:hover, .ksb:hover {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#282828), to(#282828));
-        background-image: -webkit-linear-gradient(top, #282828, #282828);
-        background-image: -moz-linear-gradient(center top, #282828, #282828);
-        background-image: -o-linear-gradient(top, #282828, #282828);
+        background-image: none;
         background-color: #282828;
         border-color: #2c2c2c;
         color: #ccc;
@@ -256,11 +226,8 @@
     /* Selected button */
     .ksb.ksbs, .ksb.ksbs:hover {
         background-color: #222;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(var(--main-bg-color)), to(#1e1e1e));
-        background-image: -webkit-linear-gradient(top, var(--main-bg-color), #1e1e1e);
-        background-image: -moz-linear-gradient(center top, var(--main-bg-color), #1e1e1e);
+        background-image: linear-gradient(to bottom, var(--main-bg-color), #1e1e1e);
         border: 1px solid #262626;
-        -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
         box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
         color: #afafaf;
         margin: 0;
@@ -430,8 +397,6 @@
 
     /* Blue icons */
     ._Jrh ._Mrh, .rllt__directions-button ._olf, ._dMi {
-        -webkit-filter: invert(0.2) !important;
-        -moz-filter: invert(0.2) !important;
         filter: invert(0.2) !important;
     }
 
@@ -471,45 +436,25 @@
         background-color: #161616 !important;
     }
     .cwlgb-tpl {
-        background-image: -moz-linear-gradient(top, #2e2e2e, #2e2e2e) !important;
-        background-image: -ms-linear-gradient(top, #2e2e2e, #2e2e2e) !important;
-        /*  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#f5f5f5,EndColorStr=#f1f1f1);*/
-        background-image: -o-linear-gradient(top, #2e2e2e, #2e2e2e) !important;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#2e2e2e), to(#2e2e2e)) !important;
-        background-image: -webkit-linear-gradient(top, #2e2e2e, #2e2e2e) !important;
+        background-image: none !important;
         background-color: #2e2e2e !important;
         border: 1px solid #353535 !important;
         color: #b3b3b3 !important;
     }
     .cwdgb-tpl {
-        background-image: -moz-linear-gradient(top, #3b3b3b, #3b3b3b) !important;
-        background-image: -ms-linear-gradient(top, #3b3b3b, #3b3b3b) !important;
-        /* filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#d6d6d6,EndColorStr=#d0d0d0);*/
-        background-image: -o-linear-gradient(top, #3b3b3b, #3b3b3b) !important;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#3b3b3b), to(#3b3b3b)) !important;
-        background-image: -webkit-linear-gradient(top, #3b3b3b, #3b3b3b) !important;
-        background-color: #d6d6d6 !important;
+        background-image: none !important;
+        background-color: #3b3b3b !important;
         border: 1px solid #484848 !important;
         color: #b3b3b3 !important;
     }
     .cwrb-tpl {
-        background-image: -moz-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        background-image: -ms-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        /*   filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#d6d6d6,EndColorStr=#d0d0d0);*/
-        background-image: -o-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#2e2e2e), to(#3b3b3b)) !important;
-        background-image: -webkit-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
+        background-image: linear-gradient(to bottom, #2e2e2e, #3b3b3b) !important;
         background-color: #2e2e2e !important;
         border: 1px solid #484848 !important;
         color: #b3b3b3 !important;
     }
     .cwdb-tpl {
-        background-image: -moz-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        background-image: -ms-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        /*   filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#d6d6d6,EndColorStr=#d0d0d0);*/
-        background-image: -o-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#2e2e2e), to(#3b3b3b)) !important;
-        background-image: -webkit-linear-gradient(top, #2e2e2e, #3b3b3b) !important;
+        background-image: linear-gradient(to bottom, #2e2e2e, #3b3b3b) !important;
         background-color: #2e2e2e !important;
         border: 1px solid #484848 !important;
         color: #b3b3b3 !important;
@@ -520,12 +465,7 @@
         color: #444 !important;
     }
     .cwbb-tpl {
-        background-image: -moz-linear-gradient(top, #656565, #656565) !important;
-        background-image: -ms-linear-gradient(top, #656565, #656565) !important;
-        /*  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr=#656565,EndColorStr=#656565);*/
-        background-image: -o-linear-gradient(top, #656565, #656565) !important;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#656565), to(#656565)) !important;
-        background-image: -webkit-linear-gradient(top, #656565, #656565) !important;
+        background-image: none !important;
         background-color: #656565 !important;
         border: 1px solid #6f6f6f !important;
     }
@@ -949,12 +889,12 @@
         border-color: #2b2b2b !important;
     }
     .kpbb {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#373737), to(#373737));
+        background-image: none;
         background-color: #373737;
         border: 1px solid #272727 !important;
     }
     .kpbb:hover {
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#626262), to(#626262));
+        background-image: none;
         background-color: #626262;
     }
     #qbut .qbptr, #qbft .qbptr {
@@ -974,8 +914,6 @@
         background: #000 !important;
     }
     .cdr_cls, .exycls {
-        -webkit-filter: invert(0.94) !important;
-        -moz-filter: invert(0.94) !important;
         filter: invert(0.94);
     }
     .cdr_dlg .goog-date-picker, .cdr_highl, .exyhlt {
@@ -997,7 +935,6 @@
     /* Share & Feedback popup */
     ._m8j, .fAwjXaCTMo5__content, div.duf3d {
         background-color: var(--main-bg-color)!important;
-        -webkit-box-shadow: 0 5px 26px 0 rgba(100,100,100,0.22) !important;
         box-shadow: 0 5px 26px 0 rgba(100,100,100,0.22) !important;
         border-color: #1d1d1d!important;
     }
@@ -1011,8 +948,6 @@
         color: #fff !important;
     }
     .duf3x, .lud-ohx {
-        -webkit-filter: invert(0.94) !important;
-        -moz-filter: invert(0.94) !important;
         filter: invert(0.94);
     }
     div.duf3c input[type=radio]:active {
@@ -1070,10 +1005,10 @@
         background-color: #151515!important;
     }
     ._zKj {
-        background: -webkit-gradient(linear,left top,right top,color-stop(0%,rgba(0,0,0,0)),color-stop(100%,rgb(21,21,21)))!important;
+        background: linear-gradient(to right,rgba(0,0,0,0),rgb(21,21,21))!important;
     }
     ._Owg {
-        background: -webkit-gradient(linear,left top,right top,color-stop(0%,rgb(22,22,22)),color-stop(100%,rgba(0,0,0,0)))!important;
+        background: linear-gradient(to right,rgb(22,22,22),rgba(0,0,0,0))!important;
     }
     .search-tool-pad, #top_nav, .msb {
         background-color: var(--main-bg-color) !important;
@@ -1205,8 +1140,6 @@
 
     /* Animated loading icon */
     g-loading-icon img {
-        -webkit-filter: grayscale(0.6) !important;
-        -moz-filter: grayscale(0.6) !important;
         filter: grayscale(0.6) !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -620,6 +620,11 @@
       border: none;
     }
 
+    /* Generated Images (e.g. in definitions) */
+    g-img {
+      filter: invert(.91) grayscale(1);
+    }
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12d
+     * Version: v3.1.12e
      */
 
      /* Main Background Color*/
@@ -697,6 +697,11 @@
     }
     ._wtf {
         filter: invert(1) !important;
+    }
+
+    /* define language select */
+    .lr_dct_trns_sel {
+        -moz-appearance: none !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.13
+     * Version: v3.1.13a
      */
 
      /* Main Background Color*/
@@ -75,7 +75,7 @@
         color: #c5c5c5 !important;
     }
     input {
-        background-color: #222 !important;
+        background-color: #2a2a2a !important;
     }
 
     /* Header */
@@ -963,10 +963,10 @@
         background-color: transparent !important;
     }
     .sbib_a, .sbibod {
-        background: #222 !important;
+        background: #2a2a2a !important;
     }
     .sbib_a:hover, .sbibod:hover {
-        background: #222 !important;
+        background: #2a2a2a !important;
     }
 
     /* New dropdown */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -5,9 +5,14 @@
      * Version: v2.1.8
      */
 
+    /* Customize main background color here */
+    :root {
+      --main-bg-color: #101010;
+    }
+
     /* Background */
     html, body, #cnt, .rg_l, #botabar, a._sWr {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
         color: #c5c5c5;
     }
     /* Inverting colors */
@@ -94,7 +99,7 @@
         border-bottom-color: #222 !important;
     }
     .mw, ._PJ {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
     }
 
     /* Footer */
@@ -109,10 +114,10 @@
         border-bottom: 1px solid #1d1d1d !important;
     }
     #appbar, #hdtbMenus, #hdtb {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
     }
     #hdtb, #hdtb.hdtba #hdtbMenus {
-        border-bottom-color: #101010 !important;
+        border-bottom-color: var(--main-bg-color) !important;
     }
 
     /* Visited links */
@@ -240,9 +245,9 @@
     /* Selected button */
     .ksb.ksbs, .ksb.ksbs:hover {
         background-color: #222;
-        background-image: -webkit-gradient(linear, left top, left bottom, from(#101010), to(#1e1e1e));
-        background-image: -webkit-linear-gradient(top, #101010, #1e1e1e);
-        background-image: -moz-linear-gradient(center top, #101010, #1e1e1e);
+        background-image: -webkit-gradient(linear, left top, left bottom, from(var(--main-bg-color)), to(#1e1e1e));
+        background-image: -webkit-linear-gradient(top, var(--main-bg-color), #1e1e1e);
+        background-image: -moz-linear-gradient(center top, var(--main-bg-color), #1e1e1e);
         border: 1px solid #262626;
         -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
         box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
@@ -309,8 +314,8 @@
         border: 1px solid #2c2c2c !important;
     }
     .sp_cnt, .srg {
-        background-color: #101010 !important;
-        outline-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
+        outline-color: var(--main-bg-color) !important;
     }
     .rc {
         background-color: transparent !important;
@@ -402,7 +407,7 @@
         color: #c5c5c5 !important;
     }
     .stt__tool .ksb, .stt__tool .goog-flat-menu-button, .stt__tool .ab_button, #topstuff .sh-sp__pswtr {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
         color: #a4a4a4 !important;
     }
     .stt__tool {
@@ -534,7 +539,7 @@
 
     /* Unit converter */
     ._Ohf, .ccw_unit_selector, .ccw_selector_bg {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
     }
     ._Ohf, ._eif, .ccw_data, .ccw_unit_selector_cnt {
         border-color: #1d1d1d !important;
@@ -584,7 +589,7 @@
     }
     /* Select */
     .lr_dct_trns_sel {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
         border-color: #1d1d1d !important;
     }
     .lr_dct_trns_sel:hover {
@@ -656,7 +661,7 @@
         border-color: #a9b1c3 transparent !important;
     }
     ._Fmb, ._Fmb:hover, ._Fmb.selected, ._Fmb.selected:hover, ._xe, ._ajl {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
     }
     .cdr_sep, .ab_dropdownrule, ._wx {
         border-top: 1px solid #474747 !important;
@@ -680,7 +685,7 @@
         background: #1d1d1d !important;
     }
     .mlo-c, .klitem:hover, g-fab._jAg._uqh, .lr_dct_lbl_box {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
     }
     ._bjl, ._Phb.rhsvw .vkc_np, #center_col .kp-blk, .cMjHbjVt9AZ__button:active {
         background: #161616 !important;
@@ -834,7 +839,7 @@
         color: rgba(255,255,255,0.87) !important;
     }
     ._vGg {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
         border-bottom-color: #252525 !important;
     }
 
@@ -914,7 +919,7 @@
 
     /* Custom image parameters search popup */
     .cdr_dlg, .exydlg {
-        background: #101010 !important;
+        background: var(--main-bg-color) !important;
         border-color: #222 !important;
         box-shadow: 0 4px 16px rgba(100,100,100,0.2) !important;
     }
@@ -944,7 +949,7 @@
 
     /* Share & Feedback popup */
     ._m8j, .fAwjXaCTMo5__content, div.duf3d {
-        background-color: #101010!important;
+        background-color: var(--main-bg-color)!important;
         -webkit-box-shadow: 0 5px 26px 0 rgba(100,100,100,0.22) !important;
         box-shadow: 0 5px 26px 0 rgba(100,100,100,0.22) !important;
         border-color: #1d1d1d!important;
@@ -971,12 +976,12 @@
         border-color: #222;
     }
     textarea._wGk.dsoVKqXxiTb__animated {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
         color: #c5c5c5;
         padding: 2px !important;
     }
     ._S9g {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
         border-color: #1d1d1d !important;
     }
     .lud-ohday {
@@ -984,7 +989,7 @@
     }
     .lud-ohdi {
         border-bottom-color: #1d1d1d !important;
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
     }
 
     /* New tab searchbar */
@@ -1024,7 +1029,7 @@
         background: -webkit-gradient(linear,left top,right top,color-stop(0%,rgb(22,22,22)),color-stop(100%,rgba(0,0,0,0)))!important;
     }
     .search-tool-pad, #top_nav, .msb {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
     }
     .srp #tsf {
         border-bottom-color: rgba(150,150,150,0.12);
@@ -1060,7 +1065,7 @@
         background-color: transparent !important;
     }
     .related-question-pair .nmca, .related-question-pair .nmtbia, .qs-iml, .qs-imr, .qs-ibg, .normal-header ._kk, .g._cy {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
     }
     #rhs .g-blk.rhsvw, .g.mnr-c.g-blk {
         background-color: transparent !important;
@@ -1084,7 +1089,7 @@
     }
     /* Promo */
     .hww53CMqxtL__mobile-promo {
-        background-color: #101010 !important;
+        background-color: var(--main-bg-color) !important;
         box-shadow: 4px 4px 12px rgba(100,100,100,0.4)!important;
     }
     /* Footer */
@@ -1114,12 +1119,12 @@
 
     /* card fix for questions */
     ._Z1m._Dou {
-        background: #101010!important;
+        background: var(--main-bg-color)!important;
     }
     /* card body */
     ._Iew, ._yHv {
         color: #989898!important;
-        background: #101010;
+        background: var(--main-bg-color);
     }
 
     /*   card title */
@@ -1168,7 +1173,7 @@
         background-color: #161616!important;
     }
     .act-tim-fs-cnt:-webkit-full-screen {
-        background-color: #101010!important;
+        background-color: var(--main-bg-color)!important;
     }
     .act-tim-txt-cnt, .act-tim-digit, .act-tim-sep {
         color: #c5c5c5;
@@ -1201,13 +1206,13 @@
         filter: invert(1);
     }
     .l4a, .f4a, .f4a.tta, .Kza {
-        background-color: #101010;
+        background-color: var(--main-bg-color);
     }
     .Kza:before {
         border-top-color: #252525;
     }
     .Kza:after {
-        border-top-color: #101010;
+        border-top-color: var(--main-bg-color);
     }
     .Jub, .Hub, .nYXukb, .xQb, .bhsVm {
         color: #c5c5c5;
@@ -1262,7 +1267,7 @@
     }
     .E4TZmd, .RIrM6d {
         /*opened notification bg*/
-        background: #101010;
+        background: var(--main-bg-color);
     }
     .utcmad {
         color: #c5c5c5;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -610,6 +610,16 @@
         color: #a6a6a6 !important;
     }
 
+    /* App Menu */
+    .gb_cc {
+      filter: invert(100%);
+    }
+
+    /* Sign In Button */
+    .gb_Fa {
+      border: none;
+    }
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.16
+     * Version: v3.1.17
      */
 
      /* Main Background Color*/
@@ -23,7 +23,7 @@
         color: #c5c5c5 !important;
     }
     /* Inverting colors */
-    .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW {
+    .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW, .fYWO0d {
         filter: invert(1) grayscale(1) !important;
     }
     ._Zgf {
@@ -119,7 +119,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
@@ -279,6 +279,9 @@
     }
     .sbsb_d {
         background: #2e2e2e !important;
+    }
+    a.aciXEb {
+        background: #222 !important;
     }
 
     /* Containers */
@@ -563,7 +566,7 @@
     }
 
     /* App Menu */
-    .gb_dc {
+    .gb_hc {
       filter: invert(1) grayscale(1) !important;
     }
 
@@ -594,7 +597,7 @@
     }
     
     /* Location Footer */
-    ._Cbu {
+    .b0KoTc {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -745,6 +748,17 @@
     ._W6g._Obq:hover g-fab {
         color: white !important;
     }
+
+    /* related items */
+    .Ss2Faf {
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
+    }
+
+    /* movie container */
+    .Ndq8Rb, .IZACzd, .WKrsIc, .piVJ4d, .RrxxYe {
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
+    }
+     
 
 
     /* ETC */
@@ -1299,7 +1313,7 @@
     }
 
     /* People also ask */
-    ._qgo {
+    .m7VU0c {
         background: #1c1c1c !important;
         border-top-color: #303030 !important;
     }

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.10
+     * Version: v3.1.10a
      */
 
      /* Main Background Color*/
@@ -119,7 +119,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12f
+     * Version: v3.1.13
      */
 
      /* Main Background Color*/
@@ -703,6 +703,22 @@
     .lr_dct_trns_sel {
         -moz-appearance: none !important;
     }
+
+    /* find my phone */
+    ._kbf {
+        border-color: rgba(255,255,255,0.4) transparent !important;
+    }
+    .goog-menu-button {
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
+    }
+
+    ._Que {
+        filter: drop-shadow(0px 0px 1px white) !important;
+    }
+    #act-fmp-signin-title {
+        color: #222;
+    }
+
 
 
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.4
+     * Version: v3.1.4a
      */
 
      /* Main Background Color*/
@@ -145,11 +145,11 @@
 
     /* visited links */
     .mblink:visited, a:visited, .sbpqs_a, a.fl:visited, .st .f .fl:visited {
-        color: /*[[VISITEDURLCOLOR]]*/ !important;
+        color: /*[[VISITEDLINKCOLOR]]*/ !important;
     }
     /* URL color */
     .a, cite, cite a:link, cite a:visited, .cite, .cite:link, #_bGc > i, .bc a:link, ._IId, ._CBw._Clt, ._PHs {
-        color: /*[[URLCOLOR]]*/ !important;
+        color: /*[[SOURCECOLOR]]*/ !important;
     }
     /* Strong Blue links */
     #hdtb-msb .hdtb-mitem.hdtb-msel, #hdtb-msb .hdtb-mitem.hdtb-msel-pre {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.5a
+     * Version: v3.1.5b
      */
 
      /* Main Background Color*/
@@ -562,7 +562,7 @@
     }
 
     /* App Menu */
-    .gb_cc {
+    .gb_dc {
       filter: invert(1) grayscale(1) !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.8
+     * Version: v3.1.9
      */
 
      /* Main Background Color*/
@@ -128,7 +128,7 @@
     }
 
     /* TextD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -308,7 +308,7 @@
         background-color: #1d1d1d !important;
         border-color: #252525 !important;
     }
-    .kp-blk .xpdclose ._wle, .kp-blk .xpdopen ._xle, #center_col ._Ak, ._Sf, ._wPc, .sh-sr__shop-result-group, #gko-sp.gko-open, ._wNi, .rllt__action-button:not(:last-child) ._nMg, ._qJg, ._UWi, ._cCh, .t7iPNCE6YvC__nav-right, .tb_view, ._BZc, .xpdclose ._T1i:not(:empty), .xpdopen ._U1i:not(:empty), .scrt tr:first-child td, .scrt td, ._UIf ._SIf, ._UIf ._hvg {
+    .kp-blk .xpdclose ._wle, .kp-blk .xpdopen ._xle, #center_col ._Ak, ._Sf, ._wPc, .sh-sr__shop-result-group, #gko-sp.gko-open, ._wNi, .rllt__action-button:not(:last-child) ._nMg, ._qJg, ._UWi, ._cCh, .t7iPNCE6YvC__nav-right, .tb_view, ._BZc, .xpdclose ._T1i:not(:empty), .xpdopen ._U1i:not(:empty), .scrt tr:first-child td, .scrt td, ._UIf ._SIf, ._UIf ._hvg, #rhs ._mbr {
         border-color: #252525 !important;
     }
     .goog-menuseparator {
@@ -723,7 +723,7 @@
     .kappbar {
         background: #1d1d1d !important;
     }
-    .mlo-c, .klitem:hover, g-fab._jAg._uqh, .lr_dct_lbl_box {
+    .mlo-c, .klitem:hover, g-fab._jAg._uqh, .lr_dct_lbl_box, .klitem.selected {
         background: var(--main-bg-color) !important;
     }
     ._bjl, ._Phb.rhsvw .vkc_np, #center_col .kp-blk, .cMjHbjVt9AZ__button:active {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -612,7 +612,7 @@
 
     /* App Menu */
     .gb_cc {
-      filter: invert(100%);
+      filter: invert(1) grayscale(1);
     }
 
     /* Sign In Button */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,12 +2,13 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.9b
+     * Version: v3.1.10
      */
 
      /* Main Background Color*/
     :root {
       --main-bg-color: /*[[MAINBGCOLOR]]*/ !important;
+      --container-bg-color: /*[[CONTAINERBGCOLOR]]*/ !important;
     }
 
     /* Fallback Color*/
@@ -265,7 +266,7 @@
 
     /* Dropdown Image colors */
     .sc a {
-        border-color: #161616 !important;
+        border-color: var(--container-bg-color) !important;
     }
 
     /* SearchBar dropdown */
@@ -282,7 +283,7 @@
 
     /* Containers */
     .vk_c, .vk_cxp, .kp-blk._Rqb._RJe, .rg_fbl, .rg_fbl:hover, .kp-blk._Jw._Rqb._RJe {
-        background: #161616 !important;
+        background: var(--container-bg-color) !important;
         box-shadow: 0 0 5px #0b0b0b !important;
     }
     ._OKe, .rl_item {
@@ -352,10 +353,10 @@
         background: #222 !important;
     }
     .rl_selected, .rl_item:hover {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     .rl_item, a.rl_item._pkf {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
         border-top: 1px solid #282828 !important;
     }
     .rl_feature .kxbcl, .rl_feature .lxhdrbox {
@@ -405,7 +406,7 @@
         border-color: #1d1d1d !important;
     }
     ._pbb, a._pbb, ._oc, ._oc .muse-wta, ._oc .richlist-wta, ._oc ._Sb {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     ._Z9b {
         color: #666 !important;
@@ -433,7 +434,7 @@
         color: #a8a8a8 !important;
     }
     .cwtlwm {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     .cwlgb-tpl {
         background-image: none !important;
@@ -581,9 +582,9 @@
         border: 1.5px solid #000000 !important;
     }
 
-    /* Dropdown Checkmarks (not yet implemented in browsers, see https://drafts.fxtf.org/filter-effects/#FilterCSSImageValue) */
+    /* Dropdown Checkmarks */
     .hdtbSel {
-        background-image: filter(url(https://ssl.gstatic.com/ui/v1/menu/checkmark2.png), invert(1)) !important;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAVCAQAAAAZIo2TAAAArElEQVQ4y+2SoQoCURBFz1tWRLYLBuF9gwhGEYtNLCJGwWr2FxTTssW+wa/wI7RaDAYNImw0XPPb3Sds1ttm7hzmDgz8lNRSvRrQU6xhFaCvVHO3F34FJow4cXC7xjteY0GHs0nyjmeLIlZYLuyLXuAMJhorBDVZY7mRmHcRcYJpwIwrR6ZEPNiarCxB7hYt6QLwYmOe5aGDXJ1yBzJiH1B2eFs72aoP0uAvvz5jAi5lzdsukgAAAABJRU5ErkJggg==) !important;
     }
 
     /* Expandable Navigation ("More", "Tools") */
@@ -617,7 +618,7 @@
         color: #EEE !important;
     }
     .pclose rect {
-        fill: #161616 !important;
+        fill: var(--container-bg-color) !important;
     }
 
     /* 'things to do' compass */
@@ -649,6 +650,22 @@
         -moz-appearance:textfield !important;
     }
     
+    /* Popular times */
+    ._Pdv {
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOBAMAAADtZjDiAAAAElBMVEUcHBwuLi4/Pz9SUlJgYGBmZmbxGvY5AAAAe0lEQVQIHQFwAI//AAAAI0QyAAAAABRVVVVBAAABVUIAJFUQAARFIBECVEAAJUURVRFUUgA1RERFEVRTADVERFEDVFQANURFIDVEVAA1REURVERTACVERERERFIABFRFIlRFQAABVUURVFUQAAAUVURVQQAAAAAjRDIAABBtEyIw7IT0AAAAAElFTkSuQmCC) !important;
+    }
+    ._tdv {
+        background: var(--container-bg-color) !important;
+    }
+    ._pdv {
+        background: #222 !important;
+    }
+    ._pdv .lubh-sel, ._pdv li:hover {
+        background: #444 !important;
+    }
+
+
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;
@@ -727,7 +744,7 @@
         background: var(--main-bg-color) !important;
     }
     ._bjl, ._Phb.rhsvw .vkc_np, #center_col .kp-blk, .cMjHbjVt9AZ__button:active {
-        background: #161616 !important;
+        background: var(--container-bg-color) !important;
     }
     .lr_dct_spkr_off input[type='image'], .lr_dct_spkr_on input[type='image'] {
         background-color: #fff !important;
@@ -973,7 +990,7 @@
         filter: invert(0.94) !important;
     }
     .cdr_dlg .goog-date-picker, .cdr_highl, .exyhlt {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     .cdr_dlg td.goog-date-picker-date:hover {
         background-color: #222 !important;
@@ -1023,7 +1040,7 @@
         border-color: #1d1d1d !important;
     }
     .lud-ohday {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     .lud-ohdi {
         border-bottom-color: #1d1d1d !important;
@@ -1081,13 +1098,13 @@
     }
     /* Search results containers */
     ._cy:not(:empty), .mnr-c:not(:empty) {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     ._OXf, ._MBh, ._U7g {
         border-color: #151515 !important;
     }
     ._Zjj, ._Dzh, .mnr-c._Dzh, ._ESj, ._RRj {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
         border-color: #151515 !important;
     }
     ._NRl, ._Fij, ._Fij a, ._jyj, ._Xbe, ._M3k, ._Iqg, ._P8d, ._xkm, ._ywh, ._uRh {
@@ -1206,7 +1223,7 @@
 
     /* Timer */
     .act-tim-txt-cnt div[style='background-color:white'] {
-        background-color: #161616 !important;
+        background-color: var(--container-bg-color) !important;
     }
     .act-tim-fs-cnt:-webkit-full-screen {
         background-color: var(--main-bg-color) !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.18
+     * Version: v3.1.19
      */
 
      /* Main Background Color*/
@@ -112,7 +112,7 @@
 
     /* Titles */
     .rllt__action-button:visited, #gsr .rllt__action-button:active, ._eMi, #sbsb_f, #sbsb_f:hover, a:link, .w, #prs a:visited, #prs a:active, .q:active, .q:visited, .kl:active, .tbotu, a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited {
-        color: /*[[LINKCOLOR]]*/ !important;
+        color: /*[[LINKCOLOR]]*/;
     }
     ._tX, ._Qqb._tX.ellip, ._Icb > a, .ab_dropdownlnkinfo:hover {
         color: /*[[LINKCOLOR]]*/ !important;
@@ -919,7 +919,7 @@
     .gb_xb:active {
         background: #343434 !important;
     }
-    #gb#gb a.gb_O, .gb_ga, .gb_Jb, .gb_wa {
+    #gb#gb a.gb_O, .gb_ga, .gb_wa {
         color: #c5c5c5 !important;
     }
     /* 3x3 grid for app switcher */
@@ -950,7 +950,7 @@
     }
 
     /* Google Account Dropdown */
-    .gb_ha, .gb_Ob, .gb_Rb, .gb_fa {
+    .gb_ha, .gb_Ob, .gb_Rb, .gb_fa, .gb_3b {
         color: #c5c5c5 !important;
     }
     .gb_mb.gb_ha.gb_g {
@@ -961,27 +961,27 @@
         /*My account button fix*/
         color: #fff !important;
     }
-    .gb_zb {
-        background-color: #1a1a1a !important;
-    }
-    .gb_Ea.gb_Cf.gb_ue.gb_yb, .gb_Ea.gb_Ef.gb_Mf.gb_ue.gb_yb {
+    .gb_Ea, #gb a.gb_Ea.gb_Ea, .gb_Fa {
         /*add account & sign out buttons*/
         background: #222 !important;
         border-color: #333 !important;
         color: #989898 !important;
     }
-    .gb_Eb {
+    .gb_Ea:hover, #gb a.gb_Ea.gb_Ea:hover, .gb_Fa:hover {
+        background: #333 !important;
+    }
+    .gb_Jb {
         /* multiLogin listing */
         background: #1d1d1d !important;
     }
-    .gb_Mb {
+    .gb_Mb, .gb_Kb {
         background: #1d1d1d !important;
     }
 
-    .gb_Ob:hover {
+    .gb_Ob:hover, .gb_Sb:hover {
         background: #333 !important;
     }
-    .gb_Fb .gb_Eb:hover {
+    .gb_Kb .gb_Jb:hover {
         /* sign out and add account button */
         background: #333 !important;
     }
@@ -991,7 +991,7 @@
     .gb_qb {
         border-bottom-color: #212121 !important;
     }
-    .gb_Db, .gb_fa, .gb_Fb {
+    .gb_Db, .gb_fa, .gb_Fb, .gb_Qb {
         /* multiLogin listing */
         background: #212121 !important;
         border-top-color: rgba(0,0,0,0.2) !important;
@@ -1002,6 +1002,9 @@
     .gb_Eb:hover, .gb_Hb:hover {
         /* multiLogin listing on hover */
         background: #1d1d1d !important;
+    }
+    .gb_vb {
+        border-bottom-color: #1d1d1d !important;
     }
 
     /* Privacy Policy */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -630,10 +630,17 @@
         border: 1.5px solid #000000;
     }
 
-    /* Dropdown checkmarks (not yet implemented in browsers, see https://drafts.fxtf.org/filter-effects/#FilterCSSImageValue) */
+    /* Dropdown Checkmarks (not yet implemented in browsers, see https://drafts.fxtf.org/filter-effects/#FilterCSSImageValue) */
     .hdtbSel {
         background-image: filter(url(https://ssl.gstatic.com/ui/v1/menu/checkmark2.png), invert(1));
     }
+
+    /* Expandable Navigation ("More", "Tools") */
+    ._dMq {
+        background: #151515;
+        box-shadow: 0px 2px 5px 0 black;
+    }
+    
 
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -630,6 +630,11 @@
         border: 1.5px solid #000000;
     }
 
+    /* Dropdown checkmarks (not yet implemented in browsers, see https://drafts.fxtf.org/filter-effects/#FilterCSSImageValue) */
+    .hdtbSel {
+        background-image: filter(url(https://ssl.gstatic.com/ui/v1/menu/checkmark2.png), invert(1));
+    }
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -643,8 +643,8 @@
 
     /* Expandable Navigation ("More", "Tools") */
     ._dMq {
-        background: #151515;
-        box-shadow: 0px 2px 5px 0 black;
+        background: #151515 !important;
+        box-shadow: 0px 2px 5px 0 black !important;
     }
     
     /* Location Footer */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12
+     * Version: v3.1.12a
      */
 
      /* Main Background Color*/
@@ -680,7 +680,10 @@
     /* related image search terms (improvement over original)*/
     a.chip span.sq {
         font-weight: bold !important;
-        text-shadow:0 0 0.3em black !important;
+        text-shadow: 0 0 0.3em black !important;
+    }
+    a.chip.xchip span.sq {
+        text-shadow: none !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -5,9 +5,9 @@
      * Version: v2.1.8
      */
 
-    /* Customize main background color here */
+     /* Main Background Color*/
     :root {
-      --main-bg-color: #101010;
+      --main-bg-color: /*[[MAINBGCOLOR]]*/;
     }
 
     /* Background */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.9a
+     * Version: v3.1.9b
      */
 
      /* Main Background Color*/
@@ -717,7 +717,7 @@
     ._M4k {
         border-color: #222 !important;
     }
-    ._Rf, .qbtbtxt.qbclr {
+    ._Rf, .qbtbtxt.qbclr, ._Rtn div {
         color: #777 !important;
     }
     .kappbar {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -601,6 +601,22 @@
         color: /*[[MAINTEXTCOLOR]]*/;
     }
 
+    /* Graphs */
+    .lcht-hldr.lcht-pw .bandaid {
+        fill: #1c1c1c;
+        stroke: #1c1c1c;
+    }
+    .lcht-hldr text.outline {
+        fill: #1c1c1c;
+        stroke: #1c1c1c;
+    }
+    .lcht-hldr .line {
+        stroke-width: 2;
+    }
+    .kpd-le-p a.kpd-en, .kpd-le.highlighted a.kpd-en {
+        color: #EEE !important;
+    }
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -119,7 +119,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb, .GtMhHe, .VQBFP a:link, .VQBFP a:visited {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
@@ -166,7 +166,7 @@
     }
 
     /* Links (white) */
-    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a, ._Y8r, ._yhs, ._oUt, .kxbcl {
+    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a, ._Y8r, ._yhs, ._oUt, .kxbcl, .Y28wmf {
         color: #a3a3a3 !important;
     }
     .gb_Q span {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  Nass O & hyperfekt
-     * Version: v3.1
+     * Version: v3.1.1
      */
 
      /* Main Background Color*/
@@ -161,7 +161,7 @@
         color: /*[[VISITEDURLCOLOR]]*/ !important;
     }
     /* URL color #69AC82 */
-    .a, cite, cite a:link, cite a:visited, .cite, .cite:link, #_bGc > i, .bc a:link, ._IId, ._CBw._Clt {
+    .a, cite, cite a:link, cite a:visited, .cite, .cite:link, #_bGc > i, .bc a:link, ._IId, ._CBw._Clt, ._PHs {
         color: /*[[URLCOLOR]]*/ !important;
     }
     /* Strong Blue links #54A6F8 */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -10,6 +10,12 @@
       --main-bg-color: /*[[MAINBGCOLOR]]*/;
     }
 
+    /* Fallback Color*/
+
+    body {
+        color: /*[[MAINTEXTCOLOR]]*/;
+    }
+
     /* Background */
     html, body, #cnt, .rg_l, #botabar, a._sWr {
         background: var(--main-bg-color) !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.14
+     * Version: v3.1.15
      */
 
      /* Main Background Color*/
@@ -732,6 +732,19 @@
         border-color: rgba(255,255,255,0.08) !important;
     }
 
+    /* tweet carousel */
+    g-fab._jAg._vqh {
+        background-color: #333 !important;
+    }
+    ._KBh {
+        box-shadow: 0 2px 2px 0 rgba(255,255,255,0.16),0 0 0 1px rgba(255,255,255,0.08) !important;
+    }
+    g-fab._jAg._vqh {
+        color: #999 !important;
+    }
+    ._W6g._Obq:hover g-fab {
+        color: white !important;
+    }
 
 
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.19
+     * Version: v3.1.20
      */
 
      /* Main Background Color*/
@@ -758,9 +758,10 @@
     }
 
     /* movie container */
-    .Ndq8Rb, .IZACzd, .WKrsIc, .piVJ4d, .RrxxYe {
+    .Ndq8Rb, .IZACzd, .WKrsIc, .piVJ4d, .RrxxYe, .NIUoNb {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
+    
      
 
 
@@ -916,9 +917,6 @@
     .gb_Z:hover:not(.gb_0) a, .gb_ma, .gb_la, .gb_ka {
         border-color: #333 !important;
     }
-    .gb_xb:active {
-        background: #343434 !important;
-    }
     #gb#gb a.gb_O, .gb_ga, .gb_wa {
         color: #c5c5c5 !important;
     }
@@ -998,10 +996,6 @@
     }
     .gb_Pb {
         color: #c5c5c5 !important;
-    }
-    .gb_Eb:hover, .gb_Hb:hover {
-        /* multiLogin listing on hover */
-        background: #1d1d1d !important;
     }
     .gb_vb {
         border-bottom-color: #1d1d1d !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.11a
+     * Version: v3.1.12
      */
 
      /* Main Background Color*/
@@ -675,6 +675,12 @@
     /* More images link */
     .kno-mrg ._iH a.fl, #iur ._iH a.fl {
         color: #fff !important;
+    }
+
+    /* related image search terms (improvement over original)*/
+    a.chip span.sq {
+        font-weight: bold !important;
+        text-shadow:0 0 0.3em black !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.15
+     * Version: v3.1.16
      */
 
      /* Main Background Color*/
@@ -947,20 +947,32 @@
     .gb_zb {
         background-color: #1a1a1a !important;
     }
-    .gb_yb:hover {
-        /*Buttons: Add account&Logout on hover*/
-        background: #333 !important;
-        border-color: #333 !important;
-    }
     .gb_Ea.gb_Cf.gb_ue.gb_yb, .gb_Ea.gb_Ef.gb_Mf.gb_ue.gb_yb {
         /*add account & sign out buttons*/
         background: #222 !important;
         border-color: #333 !important;
         color: #989898 !important;
     }
-    .gb_Cb, .gb_Eb {
+    .gb_Eb {
         /* multiLogin listing */
         background: #1d1d1d !important;
+    }
+    .gb_Mb {
+        background: #1d1d1d !important;
+    }
+
+    .gb_Ob:hover {
+        background: #333 !important;
+    }
+    .gb_Fb .gb_Eb:hover {
+        /* sign out and add account button */
+        background: #333 !important;
+    }
+    .gb_Zb {
+        color: #c5c5c5 !important;
+    }
+    .gb_qb {
+        border-bottom-color: #212121 !important;
     }
     .gb_Db, .gb_fa, .gb_Fb {
         /* multiLogin listing */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -616,6 +616,9 @@
     .kpd-le-p a.kpd-en, .kpd-le.highlighted a.kpd-en {
         color: #EEE !important;
     }
+    .pclose rect {
+        fill: #161616;
+    }
 
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.5
+     * Version: v3.1.5a
      */
 
      /* Main Background Color*/
@@ -118,7 +118,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -165,7 +165,7 @@
     }
 
     /* Links (white) */
-    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a {
+    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a {
         color: #a3a3a3 !important;
     }
     .gb_Q span {
@@ -594,6 +594,10 @@
     
     /* Location Footer */
     ._Cbu {
+        color: /*[[MAINTEXTCOLOR]]*/;
+    }
+
+    #hptl a{
         color: /*[[MAINTEXTCOLOR]]*/;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.6
+     * Version: v3.1.7
      */
 
      /* Main Background Color*/
@@ -632,6 +632,11 @@
     /* twitter icon border */
     ._U8r {
         border: 1px solid;
+    }
+
+    /* time differences */
+    ._SZc {
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
     
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.17
+     * Version: v3.1.18
      */
 
      /* Main Background Color*/
@@ -573,6 +573,9 @@
     /* Sign In Button */
     .gb_Fa {
       border: none !important;
+    }
+    #gb a.gb_Fa.gb_Fa {
+      color: #fff !important;
     }
 
     /* Generated Images */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -686,6 +686,11 @@
         text-shadow: none !important;
     }
 
+    /* icon selector */
+    ._GCg:hover {
+        box-shadow: 0 3px 8px 0 rgba(255,255,255,0.2),0 0 0 1px rgba(255,255,255,0.08) !important;
+    }
+
 
 
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -129,7 +129,7 @@
     }
 
     /* TextD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs, ._DSo {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs, ._DSo, .ads-ad, .cwUqwd, .y8Jpof .LrzXr, .garHBe, .ptJHdc .v7hl4d, .cYBBsb, .wEE4ud, .uhLbob {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -408,11 +408,17 @@
     .flt-actionblock, .commercial-unit-desktop-top, .commercial-unit-desktop-rhs, .pla-unit-container, ._HSb, .commercial-unit-desktop-top, .commercial-unit-desktop-rhs {
         border-color: #1d1d1d !important;
     }
-    ._pbb, a._pbb, ._oc, ._oc .muse-wta, ._oc .richlist-wta, ._oc ._Sb {
+    ._pbb, a._pbb, ._oc, ._oc .muse-wta, ._oc .richlist-wta, ._oc ._Sb, .WJVMff, .pla-hovercard-container {
         background-color: var(--container-bg-color) !important;
     }
     ._Z9b {
         color: #666 !important;
+    }
+    .i3YBTb {
+        color: #c5c5c5 !important;
+    }
+    .rhsvw:hover {
+        background: var(--main-bg-color) !important;
     }
     /* Annnonce */
     ._mB {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -135,7 +135,7 @@
     }
 
     /* Text #BDBDBD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah {
         color: #adadad !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.9
+     * Version: v3.1.9a
      */
 
      /* Main Background Color*/
@@ -118,7 +118,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
@@ -128,7 +128,7 @@
     }
 
     /* TextD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs, ._DSo {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -804,7 +804,7 @@
     .gb_xb:active {
         background: #343434 !important;
     }
-    #gb#gb a.gb_O, .gb_ga, .gb_Jb {
+    #gb#gb a.gb_O, .gb_ga, .gb_Jb, .gb_wa {
         color: #c5c5c5 !important;
     }
     /* 3x3 grid for app switcher */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1,8 +1,8 @@
 @-moz-document regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://www.google.(com|([a-z]{2}))(.[a-z]{2})?/_/chrome/newtab\\?.*') {
     /*
      * Name:    DarkSearch for Google (updated)
-     * Author:  Nass O
-     * Version: v2.2.0
+     * Author:  Nass O & hyperfekt
+     * Version: v3
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.5b
+     * Version: v3.1.6
      */
 
      /* Main Background Color*/
@@ -165,7 +165,7 @@
     }
 
     /* Links (white) */
-    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a {
+    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a, ._Y8r, ._yhs, ._oUt {
         color: #a3a3a3 !important;
     }
     .gb_Q span {
@@ -281,7 +281,7 @@
     }
 
     /* Containers */
-    .vk_c, .vk_cxp, .kp-blk._zCd._Rqb._RJe, .rg_fbl, .rg_fbl:hover, .kp-blk._Jw._Rqb._RJe {
+    .vk_c, .vk_cxp, .kp-blk._Rqb._RJe, .rg_fbl, .rg_fbl:hover, .kp-blk._Jw._Rqb._RJe {
         background: #161616 !important;
         box-shadow: 0 0 5px #0b0b0b !important;
     }
@@ -627,6 +627,11 @@
     /* 'things to do' borders */
     ._G4n td {
         border-color: #636363;
+    }
+
+    /* twitter icon border */
+    ._U8r {
+        border: 1px solid;
     }
     
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12a
+     * Version: v3.1.12b
      */
 
      /* Main Background Color*/
@@ -166,14 +166,14 @@
     }
 
     /* Links (white) */
-    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a, ._Y8r, ._yhs, ._oUt {
+    .flt-date, .price, ._rl, td._xh.vk_gy._Vi, div._b5e .vk_bk, ._dDh._XDh, ._xZc, ._wD ._Xbe, ._Tsf, .hdtb-mn-hd, ._tvg, ._LJ .exp-txt-c, .mod, ._eF, .rg_bb_label, #hdtb-msb #hdtb-more, #hdtb-msb #hdtb-tls, ._pk, a.fl, a._Gs, #hdtb .hdtb-mitem a, .ftl, #footer a, #gb#gb a.gb_P, #gb#gb span.gb_P, ._HR a, #swml a, #hptl a, ._Y8r, ._yhs, ._oUt, .kxbcl {
         color: #a3a3a3 !important;
     }
     .gb_Q span {
         opacity: 1 !important;
     }
     /* Hover links (white) */
-    a._Gs:hover, ._HR a, #swml a:hover, .hdtbItm label:hover, .hdtbItm a:hover, #hdtb-more-mn a:hover, #hdtb .hdtb-mitem a:hover, .hdtb-mn-hd:hover, #hdtb-more:hover, #hdtb-tls:hover {
+    a._Gs:hover, ._HR a, #swml a:hover, .hdtbItm label:hover, .hdtbItm a:hover, #hdtb-more-mn a:hover, #hdtb .hdtb-mitem a:hover, .hdtb-mn-hd:hover, #hdtb-more:hover, #hdtb-tls:hover, .kxbcl .kxbc:hover {
         color: #e1e1e1 !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -119,7 +119,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb, .GtMhHe, .VQBFP a:link, .VQBFP a:visited, .LWyAN {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb, .GtMhHe, .VQBFP a:link, .VQBFP a:visited, .LWyAN, div.nnbOwe a {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -738,6 +738,10 @@
     }
     .gb_ka {
         background-color: #1d1d1d;
+        color: #c5c5c5 !important;
+    }
+    .gb_ja {
+        color: #c5c5c5 !important;
     }
     .gb_kb, .gb_lb {
         border-bottom-color: #212121!important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1,8 +1,8 @@
-@-moz-document regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://www.google.(com|([a-z]{2}))(.[a-z]{2})?/_/chrome/newtab\\?.*') {
+@-moz-document regexp('https?://(ipv4|www|encrypted).google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://(ipv4|www|encrypted).google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://www.google.(com|([a-z]{2}))(.[a-z]{2})?/_/chrome/newtab\\?.*') {
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12b
+     * Version: v3.1.12c
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -7,19 +7,19 @@
 
      /* Main Background Color*/
     :root {
-      --main-bg-color: /*[[MAINBGCOLOR]]*/;
+      --main-bg-color: /*[[MAINBGCOLOR]]*/ !important;
     }
 
     /* Fallback Color*/
 
     body {
-        color: /*[[MAINTEXTCOLOR]]*/;
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
     /* Background */
     html, body, #cnt, .rg_l, #botabar, a._sWr {
         background: var(--main-bg-color) !important;
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     /* Inverting colors */
     .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW {
@@ -39,12 +39,12 @@
     }
     /* Images opacity */
     #hplogo, #logo img, .gbii {
-        opacity: 0.7;
-        transition: opacity 0.2s;
+        opacity: 0.7 !important;
+        transition: opacity 0.2s !important;
     }
     #hplogo:hover, #logo img:hover, .gbii:hover {
-        opacity: 1;
-        transition: opacity 0.5s;
+        opacity: 1 !important;
+        transition: opacity 0.5s !important;
     }
 
     /* Scrollbar Chrome*/
@@ -74,14 +74,14 @@
         color: #c5c5c5 !important;
     }
     input {
-        background-color: #222;
+        background-color: #222 !important;
     }
 
     /* Header */
     .sfbgg {
         background-color: #151515 !important;
         border-bottom: none !important;
-        background-image: none;
+        background-image: none !important;
     }
     .sfbgx {
         background-color: #151515 !important;
@@ -111,7 +111,7 @@
 
     /* Titles */
     .rllt__action-button:visited, #gsr .rllt__action-button:active, ._eMi, #sbsb_f, #sbsb_f:hover, a:link, .w, #prs a:visited, #prs a:active, .q:active, .q:visited, .kl:active, .tbotu, a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited {
-        color: /*[[LINKCOLOR]]*/;
+        color: /*[[LINKCOLOR]]*/ !important;
     }
     ._tX, ._Qqb._tX.ellip, ._Icb > a, .ab_dropdownlnkinfo:hover {
         color: /*[[LINKCOLOR]]*/ !important;
@@ -140,7 +140,7 @@
 
     /* Matching words in search results */
     .ads-creative b, .s .st em, .st.s.std em {
-        color: #bdbdbd;
+        color: #bdbdbd !important;
     }
 
     /* visited links */
@@ -161,7 +161,7 @@
     }
     /* Strong White links */
     .kno-ecr-pt {
-        color: #eee!important;
+        color: #eee !important;
     }
 
     /* Links (white) */
@@ -169,7 +169,7 @@
         color: #a3a3a3 !important;
     }
     .gb_Q span {
-        opacity: 1;
+        opacity: 1 !important;
     }
     /* Hover links (white) */
     a._Gs:hover, ._HR a, #swml a:hover, .hdtbItm label:hover, .hdtbItm a:hover, #hdtb-more-mn a:hover, #hdtb .hdtb-mitem a:hover, .hdtb-mn-hd:hover, #hdtb-more:hover, #hdtb-tls:hover {
@@ -178,32 +178,32 @@
 
     /* Mini search button */
     #sblsbb, #sblsbb:hover {
-        background-color: #2e2e2e;
+        background-color: #2e2e2e !important;
     }
 
     /* Button Shadow */
     .jhp input[type='submit'], .sbdd_a input, .gbqfba {
-        background-image: none;
-        background-color: #222;
-        border-color: #242424;
-        color: #acacac;
-        box-shadow: 0 0 5px #0f0f0f;
+        background-image: none !important;
+        background-color: #222 !important;
+        border-color: #242424 !important;
+        color: #acacac !important;
+        box-shadow: 0 0 5px #0f0f0f !important;
     }
 
     /* Button Shadow Hover */
     .jhp input[type='submit']:hover, .sbdd_a input:hover, .gbqfba:hover {
-        background-image: none;
-        background-color: #2e2e2e;
-        border-color: #2d2d2d;
-        color: #ccc;
-        box-shadow: 0 0 5px #0f0f0f;
+        background-image: none !important;
+        background-color: #2e2e2e !important;
+        border-color: #2d2d2d !important;
+        color: #ccc !important;
+        box-shadow: 0 0 5px #0f0f0f !important;
     }
 
     /* Button */
     .ab_button, #hdtb-tls:hover, .ksb {
-        background-image: none;
-        background-color: #222;
-        border-color: #262626;
+        background-image: none !important;
+        background-color: #222 !important;
+        border-color: #262626 !important;
         color: #acacac !important;
     }
     #hdtb-msb .hdtb-tl-sel, #hdtb-msb .hdtb-tl-sel:hover {
@@ -217,20 +217,20 @@
 
     /* Button Hover */
     .ab_button:hover, .ksb:hover {
-        background-image: none;
-        background-color: #282828;
-        border-color: #2c2c2c;
-        color: #ccc;
+        background-image: none !important;
+        background-color: #282828 !important;
+        border-color: #2c2c2c !important;
+        color: #ccc !important;
     }
 
     /* Selected button */
     .ksb.ksbs, .ksb.ksbs:hover {
-        background-color: #222;
-        background-image: linear-gradient(to bottom, var(--main-bg-color), #1e1e1e);
-        border: 1px solid #262626;
-        box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        color: #afafaf;
-        margin: 0;
+        background-color: #222 !important;
+        background-image: linear-gradient(to bottom, var(--main-bg-color), #1e1e1e) !important;
+        border: 1px solid #262626 !important;
+        box-shadow: inset 0 1px 2px rgba(0,0,0,0.1) !important;
+        color: #afafaf !important;
+        margin: 0 !important;
     }
 
     /* Disabled button */
@@ -270,14 +270,14 @@
 
     /* SearchBar dropdown */
     .sbsb_a {
-        background: #222;
+        background: #222 !important;
     }
     .sbdd_b {
-        border: 1px solid #222;
-        border-top-color: #2e2e2e;
+        border: 1px solid #222 !important;
+        border-top-color: #2e2e2e !important;
     }
     .sbsb_d {
-        background: #2e2e2e;
+        background: #2e2e2e !important;
     }
 
     /* Containers */
@@ -321,7 +321,7 @@
     .ktf {
         background-color: #222 !important;
         color: #c5c5c5 !important;
-        border-color: #262626;
+        border-color: #262626 !important;
     }
     ._zF, .mslg .ab_button, .mslg .kpgrb {
         border: 1px solid #262626 !important;
@@ -355,7 +355,7 @@
         background-color: #161616 !important;
     }
     .rl_item, a.rl_item._pkf {
-        background-color: #161616;
+        background-color: #161616 !important;
         border-top: 1px solid #282828 !important;
     }
     .rl_feature .kxbcl, .rl_feature .lxhdrbox {
@@ -373,7 +373,7 @@
     }
 
     /* Titles in containers */
-    div[style='color:#777;vertical-align:top'], span._xdb a.fl, ._W5e._X5e a, ._yE ._wI, ._W5e {
+    div[style='color:#777 !important;vertical-align:top'], span._xdb a.fl, ._W5e._X5e a, ._yE ._wI, ._W5e {
         color: #ccc !important;
     }
     div._uhe a._Zjg span.rhsg3, #irl_r_a, .qbtbtxt.qbclr:hover {
@@ -421,7 +421,7 @@
         color: rgba(224,224,224,0.87) !important;
     }
     ._jug {
-        filter: invert(1)!important;
+        filter: invert(1) !important;
     }
 
     /* Calculator */
@@ -475,16 +475,16 @@
     }
     /* shape calculator/equations */
     .lr-fy-eq.lr-fy-eq-elem {
-        color: #989898!important;
+        color: #989898 !important;
     }
     .lr-fy-eq-add:not(.lr-fy-eq-elem) {
-        background-color: #989898!important;
+        background-color: #989898 !important;
     }
     .lr-fy-tb {
-        border-color: #333!important;
+        border-color: #333 !important;
     }
     .lr-fy-tb:focus {
-        border-color: #989898!important;
+        border-color: #989898 !important;
     }
 
 
@@ -498,7 +498,7 @@
 
     /* Translator */
     .tw-lang-selector-wrapper {
-        border: none!important;
+        border: none !important;
     }
     .tw-lang-selector {
         color: #8e8e8e !important;
@@ -518,11 +518,11 @@
         border-color: #202020 !important;
     }
     .tw-menu-btn {
-        /*  opacity: 0.3!important;*/
+        /*  opacity: 0.3 !important;*/
         color: rgba(255,255,255,0.54) !important;
     }
     .tw-menu-btn:hover {
-        /*opacity: 1!important;*/
+        /*opacity: 1 !important;*/
         color: rgba(208,208,208,0.87) !important;
     }
 
@@ -533,7 +533,7 @@
         color: #747474 !important;
     }
     option {
-        background: #222;
+        background: #222 !important;
     }
     .tw-bilingual-entries .tw-bilingual-marked, .tw-bilingual-entries .tw-bilingual-marked * {
         color: rosybrown !important;
@@ -554,8 +554,8 @@
         border: 1px solid #181818 !important;
     }
     ._akb {
-        background-color: #cacaca;
-        border-top: 2px solid #989898;
+        background-color: #cacaca !important;
+        border-top: 2px solid #989898 !important;
     }
     .vk_bk.sol-tmp, .wob_t .vk_bk, .vk_bk, .vk_bk.wob-unit, .tw-bilingual-entry, .vk_ans.vk_bk, .curtgt {
         color: #a6a6a6 !important;
@@ -563,27 +563,27 @@
 
     /* App Menu */
     .gb_cc {
-      filter: invert(1) grayscale(1);
+      filter: invert(1) grayscale(1) !important;
     }
 
     /* Sign In Button */
     .gb_Fa {
-      border: none;
+      border: none !important;
     }
 
     /* Definition Images */
     #lr_dct_img_use, img[id^="lr_dct_img_origin_"] {
-      filter: invert(.91) grayscale(1);
+      filter: invert(.91) grayscale(1) !important;
     }
 
     /* Video Thumbnails */
     .th {
-        border: 1.5px solid #000000;
+        border: 1.5px solid #000000 !important;
     }
 
     /* Dropdown Checkmarks (not yet implemented in browsers, see https://drafts.fxtf.org/filter-effects/#FilterCSSImageValue) */
     .hdtbSel {
-        background-image: filter(url(https://ssl.gstatic.com/ui/v1/menu/checkmark2.png), invert(1));
+        background-image: filter(url(https://ssl.gstatic.com/ui/v1/menu/checkmark2.png), invert(1)) !important;
     }
 
     /* Expandable Navigation ("More", "Tools") */
@@ -594,11 +594,11 @@
     
     /* Location Footer */
     ._Cbu {
-        color: /*[[MAINTEXTCOLOR]]*/;
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
     #hptl a{
-        color: /*[[MAINTEXTCOLOR]]*/;
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
     /* Graphs */
@@ -611,7 +611,7 @@
         stroke: #1c1c1c !important;
     }
     .lcht-hldr .line {
-        stroke-width: 2;
+        stroke-width: 2 !important;
     }
     .kpd-le-p a.kpd-en, .kpd-le.highlighted a.kpd-en {
         color: #EEE !important;
@@ -643,7 +643,7 @@
     .knowledge-webanswers_table__webanswers-table th {
         color: #a2a2a2 !important;
     }
-    td[style='border-right: 1px solid #1d1d1d;width:50%;'], td[style='border-right:1px solid #ebebeb;width:50%'], .tb_l {
+    td[style='border-right: 1px solid #1d1d1d !important;width:50% !important;'], td[style='border-right:1px solid #ebebeb !important;width:50%'], .tb_l {
         border-color: #252525 !important;
     }
     ._uS {
@@ -656,7 +656,7 @@
         background-color: #1d1d1d !important;
     }
     g-inner-card {
-        background-color: transparent!important;
+        background-color: transparent !important;
     }
     .prpe:hover {
         background: #000 !important;
@@ -702,7 +702,7 @@
     }
     .lr_dct_spkr_off input[type='image'], .lr_dct_spkr_on input[type='image'] {
         background-color: #fff !important;
-        filter: invert(0.9);
+        filter: invert(0.9) !important;
     }
     ._nPe, ._RMe, ._OFe, ._PFe, ._QFe, ._RFe, ._gah, ._L9g, ._Usf, ._x2i ._baf b, ._mgh, ._cke, ._kGl, ._oGl, ._N2n, ._NEd, ._Fpi ._uii {
         color: rgba(255,255,255,0.87) !important;
@@ -717,17 +717,17 @@
         border-bottom-color: #1d1d1d !important;
     }
     ._cXm {
-        filter: invert(0.5);
+        filter: invert(0.5) !important;
     }
     ._vap {
-        border-color: #9baed2 transparent;
+        border-color: #9baed2 transparent !important;
     }
     #cnt.rfli .mw {
-        background-color: #151515!important;
+        background-color: #151515 !important;
     }
     #rllhd__fldhc {
-        border-bottom-color: #252525!important;
-        background-color: #151515!important;
+        border-bottom-color: #252525 !important;
+        background-color: #151515 !important;
     }
 
     /* Special Events (euro, world cup, olympics) */
@@ -753,34 +753,34 @@
 
     /* Frontpage Aplications Dropdown */
     .gb_ja, .gb_Z:hover .gb_3, ul[aria-dropeffect='move'] {
-        background-color: #212121;
+        background-color: #212121 !important;
     }
     .gb_ha {
-        background-color: #212121;
-        border-color: #212121;
+        background-color: #212121 !important;
+        border-color: #212121 !important;
     }
     .gb_ka {
-        background-color: #1d1d1d;
+        background-color: #1d1d1d !important;
         color: #c5c5c5 !important;
     }
     .gb_ja {
         color: #c5c5c5 !important;
     }
     .gb_kb, .gb_lb {
-        border-bottom-color: #212121!important;
+        border-bottom-color: #212121 !important;
     }
     .gb_Z:hover:not(.gb_0) a, .gb_ma, .gb_la, .gb_ka {
-        border-color: #333;
+        border-color: #333 !important;
     }
     .gb_xb:active {
-        background: #343434;
+        background: #343434 !important;
     }
     #gb#gb a.gb_O, .gb_ga, .gb_Jb {
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     /* 3x3 grid for app switcher */
     .gb_fa .gb_b, .gb_4b, .gb_b.gb_6b {
-        filter: invert(0.7);
+        filter: invert(0.7) !important;
     }
 
     /* Google Notifications Dropdown */
@@ -792,17 +792,17 @@
         border-color: #212121 !important;
     }
     .gb_Ec.gb_Fc, .gb_Fc.gb_Hc, .gb_Hc.gb_Ic.gb_6b {
-        filter: invert(1) brightness(0.9) contrast(0.87);
+        filter: invert(1) brightness(0.9) contrast(0.87) !important;
     }
     .ez1Qqf {
-        background: #1d1d1d!important;
+        background: #1d1d1d !important;
     }
     .qXj2He {
         color: rgba(255,255,255,0.54) !important;
     }
     /* border around dropdown thing */
     #gbsfw {
-        border-color: #333!important;
+        border-color: #333 !important;
     }
 
     /* Google Account Dropdown */
@@ -811,41 +811,41 @@
     }
     .gb_mb.gb_ha.gb_g {
         /* account dropdown panel (top and bottom) */
-        background: #212121;
+        background: #212121 !important;
     }
     #gb .gb_rb a.gb_xb.gb_xb {
         /*My account button fix*/
         color: #fff !important;
     }
     .gb_zb {
-        background-color: #1a1a1a;
+        background-color: #1a1a1a !important;
     }
     .gb_yb:hover {
         /*Buttons: Add account&Logout on hover*/
-        background: #333!important;
-        border-color: #333!important;
+        background: #333 !important;
+        border-color: #333 !important;
     }
     .gb_Ea.gb_Cf.gb_ue.gb_yb, .gb_Ea.gb_Ef.gb_Mf.gb_ue.gb_yb {
         /*add account & sign out buttons*/
-        background: #222;
-        border-color: #333;
-        color: #989898!important;
+        background: #222 !important;
+        border-color: #333 !important;
+        color: #989898 !important;
     }
     .gb_Cb, .gb_Eb {
         /* multiLogin listing */
-        background: #1d1d1d;
+        background: #1d1d1d !important;
     }
     .gb_Db, .gb_fa, .gb_Fb {
         /* multiLogin listing */
-        background: #212121;
-        border-top-color: rgba(0,0,0,0.2);
+        background: #212121 !important;
+        border-top-color: rgba(0,0,0,0.2) !important;
     }
     .gb_Pb {
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     .gb_Eb:hover, .gb_Hb:hover {
         /* multiLogin listing on hover */
-        background: #1d1d1d;
+        background: #1d1d1d !important;
     }
 
     /* Privacy Policy */
@@ -859,7 +859,7 @@
 
     /* New Search bar */
     .sbibod .sbico-c:hover {
-        background-color: transparent;
+        background-color: transparent !important;
     }
     .sbib_a, .sbibod {
         background: #222 !important;
@@ -910,19 +910,19 @@
         color: #909090 !important;
     }
     input#qbfile {
-        background: #141414;
+        background: #141414 !important;
     }
     .ktf:hover {
         border-color: #2b2b2b !important;
     }
     .kpbb {
-        background-image: none;
-        background-color: #373737;
+        background-image: none !important;
+        background-color: #373737 !important;
         border: 1px solid #272727 !important;
     }
     .kpbb:hover {
-        background-image: none;
-        background-color: #626262;
+        background-image: none !important;
+        background-color: #626262 !important;
     }
     #qbut .qbptr, #qbft .qbptr {
         border-bottom-color: #131313 !important;
@@ -941,7 +941,7 @@
         background: #000 !important;
     }
     .cdr_cls, .exycls {
-        filter: invert(0.94);
+        filter: invert(0.94) !important;
     }
     .cdr_dlg .goog-date-picker, .cdr_highl, .exyhlt {
         background-color: #161616 !important;
@@ -961,9 +961,9 @@
 
     /* Share & Feedback popup */
     ._m8j, .fAwjXaCTMo5__content, div.duf3d {
-        background-color: var(--main-bg-color)!important;
+        background-color: var(--main-bg-color) !important;
         box-shadow: 0 5px 26px 0 rgba(100,100,100,0.22) !important;
-        border-color: #1d1d1d!important;
+        border-color: #1d1d1d !important;
     }
     ._dyj, ._Gxj, ._Dfm, .lud-ohdf {
         color: rgba(255,255,255,0.87) !important;
@@ -975,18 +975,18 @@
         color: #fff !important;
     }
     .duf3x, .lud-ohx {
-        filter: invert(0.94);
+        filter: invert(0.94) !important;
     }
     div.duf3c input[type=radio]:active {
-        border-color: #333;
-        background: #222;
+        border-color: #333 !important;
+        background: #222 !important;
     }
     div.duf3c input[type=radio], .lud-asi, .duf3bs {
-        border-color: #222;
+        border-color: #222 !important;
     }
     textarea._wGk.dsoVKqXxiTb__animated {
         background-color: var(--main-bg-color) !important;
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
         padding: 2px !important;
     }
     ._S9g {
@@ -1003,23 +1003,23 @@
 
     /* New tab searchbar */
     #fkbx {
-        background-color: #222;
-        border-color: #222;
+        background-color: #222 !important;
+        border-color: #222 !important;
     }
     #fkbx:hover {
-        border-color: #282828;
+        border-color: #282828 !important;
     }
 
     /* Google logo (if needed) */
     /*@media (-webkit-max-device-pixel-ratio: 1), (max-resolution: 96dpi)
     #hplogo {
-        background: url(/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png) no-repeat;
+        background: url(/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png) no-repeat !important;
     }
     */
 
     /* Additional infos on website (e.g. creation date) */
     ._cwc {
-        color: #b7b7b7;
+        color: #b7b7b7 !important;
     }
 
     /* Mobile */
@@ -1029,43 +1029,43 @@
         border-color: #303030 !important;
     }
     #hdtb-more, #hdtb-msb .hdtb-imb, #hdtb-msb .hdtb-imb.hdtb-msel, #hdtb-tls, #msc {
-        background-color: #151515!important;
+        background-color: #151515 !important;
     }
     ._zKj {
-        background: linear-gradient(to right,rgba(0,0,0,0),rgb(21,21,21))!important;
+        background: linear-gradient(to right,rgba(0,0,0,0),rgb(21,21,21)) !important;
     }
     ._Owg {
-        background: linear-gradient(to right,rgb(22,22,22),rgba(0,0,0,0))!important;
+        background: linear-gradient(to right,rgb(22,22,22),rgba(0,0,0,0)) !important;
     }
     .search-tool-pad, #top_nav, .msb {
         background-color: var(--main-bg-color) !important;
     }
     .srp #tsf {
-        border-bottom-color: rgba(150,150,150,0.12);
+        border-bottom-color: rgba(150,150,150,0.12) !important;
     }
     /* Search suggestions */
     .sbmsq_a {
-        background-color: #1d1d1d!important;
+        background-color: #1d1d1d !important;
     }
     .sbsb_e {
-        background-color: #333!important;
+        background-color: #333 !important;
     }
     /* Search results containers */
     ._cy:not(:empty), .mnr-c:not(:empty) {
         background-color: #161616 !important;
     }
     ._OXf, ._MBh, ._U7g {
-        border-color: #151515!important;
+        border-color: #151515 !important;
     }
     ._Zjj, ._Dzh, .mnr-c._Dzh, ._ESj, ._RRj {
-        background-color: #161616!important;
-        border-color: #151515!important;
+        background-color: #161616 !important;
+        border-color: #151515 !important;
     }
     ._NRl, ._Fij, ._Fij a, ._jyj, ._Xbe, ._M3k, ._Iqg, ._P8d, ._xkm, ._ywh, ._uRh {
-        color: rgba(255,255,255,0.87)!important;
+        color: rgba(255,255,255,0.87) !important;
     }
     ._OPd._Cnk a, #brs ._ryh, ._kk, ._bMc, ._D8e, ._Obi, ._Obi a, ._xdb, ._xdb a.fl, a.duf3, ._hap, ._pLp, ._Mnc, ._Jse, span._Gxg, ._Akh, ._wkm, ._jmp, ._zwh, ._vRh, ._LMk {
-        color: rgba(255,255,255,0.54)!important;
+        color: rgba(255,255,255,0.54) !important;
     }
     #brs a {
         color: #9baed2 !important;
@@ -1078,85 +1078,85 @@
     }
     #rhs .g-blk.rhsvw, .g.mnr-c.g-blk {
         background-color: transparent !important;
-        box-shadow: none!important;
+        box-shadow: none !important;
     }
     /* Mobile ETC */
     a.q.qs, ._jgc, ._bC, ._tic, ._aD, ._IAp, ._ucl, a ._n4d {
         color: #a6a6a6 !important;
     }
     ._D7k ._B7k:last-child, ._D7k ._c8k:last-child, ._D7k ._ISm:last-child, ._D7k ._C7k, ._A7k:not(:last-child) ._B7k:last-child, ._A7k:not(:last-child) ._c8k:last-child, ._A7k:not(:last-child) ._ISm:last-child, ._A7k:not(:last-child) ._C7k, ._c5d {
-        border-color: #1d1d1d!important;
+        border-color: #1d1d1d !important;
     }
     /* Round button */
     g-fab._wxg._Axg.xcas._jAg._vqh, g-fab._wxg._Bxg.xcae._jAg._vqh {
-        background-color: #1d1d1d!important;
-        color: rgba(255,255,255,0.54)!important;
+        background-color: #1d1d1d !important;
+        color: rgba(255,255,255,0.54) !important;
     }
     /* Next & install button */
     ._mk, #fbtns .ksb, ._Aji {
-        background-color: #222!important;
+        background-color: #222 !important;
     }
     /* Promo */
     .hww53CMqxtL__mobile-promo {
         background-color: var(--main-bg-color) !important;
-        box-shadow: 4px 4px 12px rgba(100,100,100,0.4)!important;
+        box-shadow: 4px 4px 12px rgba(100,100,100,0.4) !important;
     }
     /* Footer */
     ._GR #swml {
-        border-color: #1d1d1d!important;
+        border-color: #1d1d1d !important;
     }
     ._SAi {
-        border-color: #252525!important;
+        border-color: #252525 !important;
     }
     .fbar {
         background: #1d1d1d !important;
     }
     #swml_addr, #fuserm span[style*='color:#333'] {
-        color: #c5c5c5!important;
+        color: #c5c5c5 !important;
     }
 
     /* Fix for header text and button text on exact size image search tool */
 
     #isz_ex > div > div > div.exydlg > div.exyttl {
-        color: #a3a3a3!important;
+        color: #a3a3a3 !important;
     }
 
     /* Google cards */
     g-card-section {
-        background: #1c1c1c;
+        background: #1c1c1c !important;
     }
 
     /* card fix for questions */
     ._Z1m._Dou {
-        background: var(--main-bg-color)!important;
+        background: var(--main-bg-color) !important;
     }
     /* card body */
     ._Iew, ._yHv {
-        color: #989898!important;
-        background: var(--main-bg-color);
+        color: #989898 !important;
+        background: var(--main-bg-color) !important;
     }
 
     /*   card title */
     ._Enw._H1m._kup._J5m {
-        color: #ccc!important;
+        color: #ccc !important;
     }
     /* card title arrows */
     ._K4m._DYo._wtf._Ctf > svg {
-        fill: #989898;
+        fill: #989898 !important;
     }
     /* card subtitle */
     ._H1m._O1m._mup._J5m, ._Qjt._H1m._P1m._mup._J5m {
-        color: #989898;
+        color: #989898 !important;
     }
     /* next and last arrow buttons */
     button._CDq._PEq._Rqu > span > svg, button._CDq._PEq._Rqu {
-        fill: #ccc!important;
-        background: #333;
+        fill: #ccc !important;
+        background: #333 !important;
     }
 
     /* card divider */
     ._zhv {
-        border-color: #989898!important;
+        border-color: #989898 !important;
     }
 
     /* People also ask */
@@ -1172,63 +1172,63 @@
 
     /* Button hover in search bar fix */
     .sbibod button:hover {
-        background: #222!important;
+        background: #222 !important;
     }
 
     /* Timer */
     .act-tim-txt-cnt div[style='background-color:white'] {
-        background-color: #161616!important;
+        background-color: #161616 !important;
     }
     .act-tim-fs-cnt:-webkit-full-screen {
-        background-color: var(--main-bg-color)!important;
+        background-color: var(--main-bg-color) !important;
     }
     .act-tim-txt-cnt, .act-tim-digit, .act-tim-sep {
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     .act-tab-link.act-inactive-tab:hover {
-        color: white;
+        color: white !important;
     }
     .act-icon-dark-gray, .act-inactive-tab .act-icon-img {
-        filter: invert(1);
+        filter: invert(1) !important;
     }
     .act-btn-row, .act-tim-fs-cnt {
-        border-top: 1px solid #1d1d1d;
+        border-top: 1px solid #1d1d1d !important;
     }
     /* Fix for card text colors */
     ._XWk {
-        color: #a6a6a6!important;
+        color: #a6a6a6 !important;
     }
 
     ._aMb {
-        color: #a6a6a6!important;
+        color: #a6a6a6 !important;
     }
 }
 
 @-moz-document regexp('https?://plus.google.(com|([a-z]{2}))(.[a-z]{2})?/u/0/_/notifications/frame\\?.*') {
     /* Google Alerts Dropdown iframe */
     .aac, .Rzc, .WdjWF, .WpuQke {
-        background-color: #212121;
+        background-color: #212121 !important;
     }
     .vKFgJc, .Ygb, .bxpCne, .tubEcf {
-        filter: invert(1);
+        filter: invert(1) !important;
     }
     .l4a, .f4a, .f4a.tta, .Kza {
-        background-color: var(--main-bg-color);
+        background-color: var(--main-bg-color) !important;
     }
     .Kza:before {
-        border-top-color: #252525;
+        border-top-color: #252525 !important;
     }
     .Kza:after {
-        border-top-color: var(--main-bg-color);
+        border-top-color: var(--main-bg-color) !important;
     }
     .Jub, .Hub, .nYXukb, .xQb, .bhsVm {
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     .MNn0h, .MNn0h:hover {
-        background: #1d1d1d;
+        background: #1d1d1d !important;
     }
     .MNn0h:hover .YGETNc, .MNn0h.RATVS .YGETNc, .y9fV .YGETNc {
-        color: #868686;
+        color: #868686 !important;
     }
 }
 
@@ -1237,56 +1237,56 @@
 
     .gV6pJf, #gbsfw.gb_Ic {
         /*dropdown background*/
-        background: #212121!important;
-        border-color: #212121;
+        background: #212121 !important;
+        border-color: #212121 !important;
     }
     .CxSKqd.PNdSh, .CxSKqd.Wj1LYb, .CxSKqd {
         /*notification background*/
-        background: #151515;
+        background: #151515 !important;
     }
     .iWO9fc .mUbCce svg, .yxaWLe svg, .ajgU6 {
         /*icons*/
-        fill: rgba(255,255,255,0.54);
+        fill: rgba(255,255,255,0.54) !important;
     }
     .iWO9fc .mUbCce:hover svg, .yxaWLe:hover svg {
         /*icons:hover*/
-        fill: rgba(255,255,255,0.87);
+        fill: rgba(255,255,255,0.87) !important;
     }
     .XSVuue {
         /*logo Google*/
-        fill: rgba(255,255,255,0.26);
+        fill: rgba(255,255,255,0.26) !important;
     }
     .v7k2xf, .v7k2xf, .gMG7Fd, .wh73ab {
         /*text*/
-        color: rgba(255,255,255,0.87);
+        color: rgba(255,255,255,0.87) !important;
     }
     .OlDqke, .Vz68Kb {
         /*subtext*/
-        color: rgba(255,255,255,0.54);
+        color: rgba(255,255,255,0.54) !important;
     }
     .fEjTrb, .jvWPmb.qs41qe .fEjTrb {
         /*footer-bar*/
-        background-color: #1d1d1d;
+        background-color: #1d1d1d !important;
     }
     .xMujpb {
         /*opened notification header bg*/
-        background-color: #1d1d1d;
+        background-color: #1d1d1d !important;
     }
     .E4TZmd, .RIrM6d {
         /*opened notification bg*/
-        background: var(--main-bg-color);
+        background: var(--main-bg-color) !important;
     }
     .utcmad {
-        color: #c5c5c5;
+        color: #c5c5c5 !important;
     }
     body, .m3JvWd, .g6UaYd, .vGowKb {
-        color: rgba(255,255,255,0.87);
+        color: rgba(255,255,255,0.87) !important;
     }
     .LCX1Id, .XGOYJd > :first-child, .ZYK0Xb {
-        border-top-color: #252525;
+        border-top-color: #252525 !important;
     }
     .GsLz7c, .sH8mib {
         /*circle icon bg*/
-        background: #212121;
+        background: #212121 !important;
     }
 }

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.10a
+     * Version: v3.1.11
      */
 
      /* Main Background Color*/
@@ -124,7 +124,7 @@
     }
 
     /* More arrow */
-    ._Fqg {
+    ._Fqg, ._DYo {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
@@ -282,7 +282,7 @@
     }
 
     /* Containers */
-    .vk_c, .vk_cxp, .kp-blk._Rqb._RJe, .rg_fbl, .rg_fbl:hover, .kp-blk._Jw._Rqb._RJe {
+    .vk_c, .vk_cxp, .kp-blk._Rqb._RJe, .rg_fbl, .rg_fbl:hover, .kp-blk._Jw._Rqb._RJe, ._Z1m {
         background: var(--container-bg-color) !important;
         box-shadow: 0 0 5px #0b0b0b !important;
     }
@@ -662,6 +662,11 @@
     }
     ._pdv .lubh-sel, ._pdv li:hover {
         background: #444 !important;
+    }
+
+    /* What is my IP */
+    ._kup, ._H1m._ees._kup._J5m {
+        color: none !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.13a
+     * Version: v3.1.14
      */
 
      /* Main Background Color*/
@@ -711,12 +711,25 @@
     .goog-menu-button {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
-
     ._Que {
         filter: drop-shadow(0px 0px 1px white) !important;
     }
     #act-fmp-signin-title {
-        color: #222;
+        color: #222 !important;
+    }
+    
+    /* people also search for */
+    .exp-outline {
+        border-color: rgba(255,255,255,0.13) !important;
+    }
+    .kN9UDnqLeMg__dismiss-button {
+        filter: invert(1) !important;
+    }
+    .kN9UDnqLeMg__carousel-caption {
+        color: rgba(255,255,255,0.57) !important;
+    }
+    .kN9UDnqLeMg__explore-main {
+        border-color: rgba(255,255,255,0.08) !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  Nass O & hyperfekt
-     * Version: v3.1.2
+     * Version: v3.1.3
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1,8 +1,8 @@
 @-moz-document regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://www.google.(com|([a-z]{2}))(.[a-z]{2})?/_/chrome/newtab\\?.*') {
     /*
-     * Name:    DarkSearch for Google
+     * Name:    DarkSearch for Google (updated)
      * Author:  Nass O
-     * Version: v2.1.8
+     * Version: v2.2.0
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -140,6 +140,11 @@
         color: /*[[LINKCOLOR]]*/ !important;
     }
 
+    /* More arrow */
+    ._Fqg {
+        color: /*[[LINKCOLOR]]*/ !important;
+    }
+
     /* TextD */
     .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah {
         color: /*[[MAINTEXTCOLOR]]*/ !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.11
+     * Version: v3.1.11a
      */
 
      /* Main Background Color*/
@@ -664,9 +664,17 @@
         background: #444 !important;
     }
 
-    /* What is my IP */
-    ._kup, ._H1m._ees._kup._J5m {
-        color: none !important;
+    /* Your public IP address */
+    ._Tlt._H1m._kup._J5m {
+        color: /*[[LINKCOLOR]]*/ !important;
+    }
+    ._H1m._u2m._kup._I5m, ._H1m._ees._kup._J5m {
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
+    }
+
+    /* More images link */
+    .kno-mrg ._iH a.fl, #iur ._iH a.fl {
+        color: #fff !important;
     }
 
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -123,15 +123,15 @@
     /* Visited links */
     /* Titles (blue) #7EB3F3 */
     .rllt__action-button:visited, #gsr .rllt__action-button:active, ._eMi, #sbsb_f, #sbsb_f:hover, a:link, .w, #prs a:visited, #prs a:active, .q:active, .q:visited, .kl:active, .tbotu, a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited {
-        color: #5e7af2;
+        color: /*[[LINKCOLOR]]*/;
     }
     ._tX, ._Qqb._tX.ellip, ._Icb > a, .ab_dropdownlnkinfo:hover {
-        color: #5e7af2 !important;
+        color: /*[[LINKCOLOR]]*/ !important;
     }
 
     /* Links (blue) #89A2CF*/
     a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht {
-        color: #5e7af2 !important;
+        color: /*[[LINKCOLOR]]*/ !important;
     }
 
     /* TextD */
@@ -152,11 +152,11 @@
 
     /* visited links #BD90D7 */
     .mblink:visited, a:visited, .sbpqs_a, a.fl:visited, .st .f .fl:visited {
-        color: #9268d4 !important;
+        color: /*[[VISITEDURLCOLOR]]*/ !important;
     }
     /* URL color #69AC82 */
     .a, cite, cite a:link, cite a:visited, .cite, .cite:link, #_bGc > i, .bc a:link, ._IId, ._CBw._Clt {
-        color: #4dab6f !important;
+        color: /*[[URLCOLOR]]*/ !important;
     }
     /* Strong Blue links #54A6F8 */
     #hdtb-msb .hdtb-mitem.hdtb-msel, #hdtb-msb .hdtb-mitem.hdtb-msel-pre {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -647,6 +647,10 @@
         box-shadow: 0px 2px 5px 0 black;
     }
     
+    /* Location Footer */
+    ._Cbu {
+        color: /*[[MAINTEXTCOLOR]]*/;
+    }
 
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  Nass O & hyperfekt
-     * Version: v3.1.1
+     * Version: v3.1.2
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.12c
+     * Version: v3.1.12d
      */
 
      /* Main Background Color*/
@@ -690,7 +690,14 @@
     ._GCg:hover {
         box-shadow: 0 3px 8px 0 rgba(255,255,255,0.2),0 0 0 1px rgba(255,255,255,0.08) !important;
     }
-
+    
+    /* define search box */
+    .dw-sb-cont .dw-sb-btn {
+        background: var(--container-bg-color) !important;
+    }
+    ._wtf {
+        filter: invert(1) !important;
+    }
 
 
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -2,7 +2,7 @@
     /*
      * Name:    DarkSearch for Google (updated)
      * Author:  hyperfekt
-     * Version: v3.1.7
+     * Version: v3.1.8
      */
 
      /* Main Background Color*/
@@ -571,8 +571,8 @@
       border: none !important;
     }
 
-    /* Definition Images */
-    #lr_dct_img_use, img[id^="lr_dct_img_origin_"] {
+    /* Generated Images */
+    #lr_dct_img_use, img[id^="lr_dct_img_origin_"], #ccw_chart {
       filter: invert(.91) grayscale(1) !important;
     }
 
@@ -626,17 +626,27 @@
     }
     /* 'things to do' borders */
     ._G4n td {
-        border-color: #636363;
+        border-color: #636363 !important;
     }
 
     /* twitter icon border */
     ._U8r {
-        border: 1px solid;
+        border: 1px solid !important;
     }
 
     /* time differences */
     ._SZc {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
+    }
+
+    /* number input spinners */
+    input[type=number]::-webkit-inner-spin-button, 
+    input[type=number]::-webkit-outer-spin-button { 
+        -webkit-appearance: none !important; 
+        margin: 0 !important;
+    }
+    input[type=number] {
+        -moz-appearance:textfield !important;
     }
     
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -603,12 +603,12 @@
 
     /* Graphs */
     .lcht-hldr.lcht-pw .bandaid {
-        fill: #1c1c1c;
-        stroke: #1c1c1c;
+        fill: #1c1c1c !important;
+        stroke: #1c1c1c !important;
     }
     .lcht-hldr text.outline {
-        fill: #1c1c1c;
-        stroke: #1c1c1c;
+        fill: #1c1c1c !important;
+        stroke: #1c1c1c !important;
     }
     .lcht-hldr .line {
         stroke-width: 2;
@@ -617,7 +617,7 @@
         color: #EEE !important;
     }
     .pclose rect {
-        fill: #161616;
+        fill: #161616 !important;
     }
 
     /* ETC */

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -625,6 +625,11 @@
       filter: invert(.91) grayscale(1);
     }
 
+    /* Video Thumbnails */
+    .th {
+        border: 1.5px solid #000000;
+    }
+
     /* ETC */
     ._Qsh, ._ae ._SDf, ._Lbe, .kltat, .klfact {
         color: #c5c5c5 !important;

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -119,7 +119,7 @@
     }
 
     /* Links */
-    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb, .GtMhHe, .VQBFP a:link, .VQBFP a:visited {
+    a.iu-card-header, a.iu-card-header:hover, a.iu-card-header:visited, a.fl:link, .fl a, .flt, a.flt, .gl a:link, a.mblink, .mblink b, #foot #navcnt a, a.fl.q._KCd._tWc, .st .f .fl, div.duf3d a, ._YAp, .lr_dct_more_btn, a ._l6b, ._Yht, ._Mft, ._CSo, ._VBr, ._m7u, .xXEKkb, .GtMhHe, .VQBFP a:link, .VQBFP a:visited, .LWyAN {
         color: /*[[LINKCOLOR]]*/ !important;
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -571,8 +571,8 @@
       border: none;
     }
 
-    /* Generated Images (e.g. in definitions) */
-    g-img {
+    /* Definition Images */
+    #lr_dct_img_use, img[id^="lr_dct_img_origin_"] {
       filter: invert(.91) grayscale(1);
     }
 

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -1,8 +1,8 @@
 @-moz-document regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://(ipv4|www).google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?/((\\?|webhp|search|gfe_rd|auth|gws_rd|#q|imghp|#gfe_rd|#safe|#pws|#tbs|#gws|#tbm).*)'), regexp('https?://encrypted.google.(com|([a-z]{2}))(.[a-z]{2})?.'), regexp('https?://www.google.(com|([a-z]{2}))(.[a-z]{2})?/_/chrome/newtab\\?.*') {
     /*
      * Name:    DarkSearch for Google (updated)
-     * Author:  Nass O & hyperfekt
-     * Version: v3.1.3
+     * Author:  hyperfekt
+     * Version: v3.1.4
      */
 
      /* Main Background Color*/

--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -134,9 +134,9 @@
         color: #5e7af2 !important;
     }
 
-    /* Text #BDBDBD */
+    /* TextD */
     .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah {
-        color: #adadad !important;
+        color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
     /* Subtext #9f9f9f */


### PR DESCRIPTION
I've fixed up a few of the colors of links and text that was difficult to read previously.
Know this place? before:
![before](https://user-images.githubusercontent.com/13175844/38844897-b7ba8184-4238-11e8-9450-28509c13038b.JPG)
After:
![after](https://user-images.githubusercontent.com/13175844/38844898-b7ee7098-4238-11e8-96be-1336e28d101e.JPG)

Review scores were also difficult to read, although the close-up picture doesn't do it justice.
![before-review](https://user-images.githubusercontent.com/13175844/38844899-b8231604-4238-11e8-9f4c-9786f82ca9c4.JPG)
![after-review](https://user-images.githubusercontent.com/13175844/38844900-b8586f7a-4238-11e8-92a3-cb16964ad368.JPG)

There were some other links that were too dark also:
![before-according](https://user-images.githubusercontent.com/13175844/38844901-b88bcd5c-4238-11e8-9303-0f698f264b7f.JPG)
![after-according](https://user-images.githubusercontent.com/13175844/38844902-b8be2388-4238-11e8-8355-796f33080122.JPG)

Finally, I fixed up sponsored ads so they would display nicer:
![before-ads](https://user-images.githubusercontent.com/13175844/38845324-55f24ae8-423a-11e8-8dec-892d9b33452b.jpg)
![after-ads](https://user-images.githubusercontent.com/13175844/38845326-56b6d426-423a-11e8-974c-94be33add093.jpg)
In both images I am highlighting the bottom right ad.