### PR TITLE
Fix coloring of 'People also search for' section

### DIFF
--- a/DarkSearch.css
+++ b/DarkSearch.css
@@ -23,7 +23,7 @@
         color: #c5c5c5 !important;
     }
     /* Inverting colors */
-    .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW, .fYWO0d {
+    .qbh, .s2tb .google-logo, #wob_gsp, ._kac, #qbi, .ab_icon, .gsok_a, ._Fnc, ._Jxg, .stt-uf, ._dVi, .kcb.checked::after, ._gW, .fYWO0d, #eobs_0 {
         filter: invert(1) grayscale(1) !important;
     }
     ._Zgf {
@@ -129,7 +129,7 @@
     }
 
     /* TextD */
-    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs, ._DSo, .ads-ad, .cwUqwd, .y8Jpof .LrzXr, .garHBe, .ptJHdc .v7hl4d, .cYBBsb, .wEE4ud, .uhLbob {
+    .rreh ._fk, span[style='color:#222'], #center_col ._Ak, #rhs ._Ak, ._i2g, ._g2g, .s, .st, ._cnc, #brs .med, ._Adb, ._tyb, .shop__secondary, .shop__secondary:link, .shop__secondary:visited, ._Lqc, .lc-loc-text, .gko-ctrl, .gko-ctrl:link, .gko-ctrl:visited, ._uxi, ._Hxi, ._gah, ._e9n, ._cNr, ._Nar, ._lhs, ._DSo, .ads-ad, .cwUqwd, .y8Jpof .LrzXr, .garHBe, .ptJHdc .v7hl4d, .cYBBsb, .wEE4ud, .uhLbob, .eJ7tvc {
         color: /*[[MAINTEXTCOLOR]]*/ !important;
     }
 
@@ -731,7 +731,7 @@
     }
     
     /* people also search for */
-    .exp-outline {
+    .exp-outline, .AUiS2 {
         border-color: rgba(255,255,255,0.13) !important;
     }
     .kN9UDnqLeMg__dismiss-button {


### PR DESCRIPTION
Some of the text, borders, and images were still difficult to see so I've updated them to have lighter colors. URL used for testing can be found [here](https://www.google.com.au/search?source=hp&ei=rzbgWuP_Nor48QXtnaPYCg&q=unity+mouse+scroll+wheel&oq=unity+scrollwheel&gs_l=psy-ab.3.2.0j0i22i10i30k1l6.12825.16801.0.21721.19.16.0.0.0.0.349.1683.0j1j5j1.7.0....0...1.1.64.psy-ab..12.7.1682.0..35i39k1j0i131k1.0.xrBo5mmxhPQ).

Before:
![before](https://user-images.githubusercontent.com/13175844/39233965-3c005d1a-48b5-11e8-974b-914083fef064.JPG)
After:
![after](https://user-images.githubusercontent.com/13175844/39233967-3d8bae5a-48b5-11e8-981a-9fbdcd4b15ee.JPG)